### PR TITLE
Allow overwriting the auth role for federated identity

### DIFF
--- a/packages/resources/src/Auth.ts
+++ b/packages/resources/src/Auth.ts
@@ -409,7 +409,6 @@ export class Auth extends cdk.Construct {
       ),
     });
 
-
     role.addToPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,


### PR DESCRIPTION
Relates to: https://github.com/aws/aws-cdk/issues/15908

# Allow TagSession to forward custom claims to the identity

This enables private client-side assumed roles, which are secured by claims within the cognito idToken

# Example Client-Side Calls to DynamoDB with Fine-Grained Control

## Stack

```ts
import * as sst from "@serverless-stack/resources";
import * as iam from "@aws-cdk/aws-iam";

export default class MyStack extends sst.Stack {
  constructor(scope: sst.App, id: string, props?: sst.StackProps) {
    super(scope, id, props);

    // Create a HTTP API
    const auth = new sst.Auth(this, 'Authentication', {
      cognito: true,
      identityPool: {
        createAuthRole: (identityPool) => {
          const role = new iam.Role(this, "IdentityPoolAuthRole", {
            assumedBy: new iam.FederatedPrincipal(
              "cognito-identity.amazonaws.com",
              {
                StringEquals: {
                  "cognito-identity.amazonaws.com:aud": identityPool.ref,
                },
                "ForAnyValue:StringLike": {
                  "cognito-identity.amazonaws.com:amr": "authenticated",
                },
              },
              // @ts-ignore
              [
                "sts:AssumeRoleWithWebIdentity",
                "sts:TagSession"
              ]
            ),
          });

          role.addToPolicy(
            new iam.PolicyStatement({
              effect: iam.Effect.ALLOW,
              actions: [
                "mobileanalytics:PutEvents",
                "cognito-sync:*",
                "cognito-identity:*",
              ],
              resources: ["*"],
            })
          );

          return role;
        }
      }
    })

    // Show the endpoint in the output
    this.addOutputs({
      "Assumed role": JSON.stringify(auth.iamAuthRole.assumeRolePolicy, undefined, 2),
    });
  }
}
```

## Outputs

```bash

 ✅  dev-latest-my-stack


Stack dev-latest-my-stack
  Status: deployed
  Outputs:
    Assumedrole: {
  "Statement": [
    {
      "Action": [
        "sts:AssumeRoleWithWebIdentity",
        "sts:TagSession"
      ],
      "Condition": {
        "StringEquals": {
          "cognito-identity.amazonaws.com:aud": "us-east-1:220a33fe-390f-4c25-a72b-f349732f9b61"
        },
        "ForAnyValue:StringLike": {
          "cognito-identity.amazonaws.com:amr": "authenticated"
        }
      },
      "Effect": "Allow",
      "Principal": {
        "Federated": "cognito-identity.amazonaws.com"
      }
    }
  ],
  "Version": "2012-10-17"
}

Done in 62.40s.

```